### PR TITLE
Add MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/rust-dark-light/rust-dark-light"
 description = "Detect if dark mode or light mode is enabled"
 readme = "README.md"
 build = "build.rs"
+rust-version = "1.78.0"
 
 [dependencies]
 futures-lite = "2.3.0"
@@ -20,7 +21,9 @@ log = "0.4.22"
 tokio = { version = "1.23.0", features = ["full"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-ashpd = { version = "0.10.0", default-features = false, features = ["async-std"] }
+ashpd = { version = "0.10.0", default-features = false, features = [
+    "async-std",
+] }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"


### PR DESCRIPTION
This pull request adds a MSRV based on `cargo-msrv`.

```
Result:
   Considered (min … max):   Rust 1.56.1 … Rust 1.84.0
   Search method:            bisect
   MSRV:                     1.78.0
   Target:                   aarch64-apple-darwin
```

Fixes #24 