### PR TITLE
Remove futures-lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,12 @@ build = "build.rs"
 rust-version = "1.78.0"
 
 [dependencies]
-futures-lite = "2.3.0"
-log = "0.4.22"
-
-[dev-dependencies]
-tokio = { version = "1.23.0", features = ["full"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 ashpd = { version = "0.10.0", default-features = false, features = [
     "async-std",
 ] }
+async-std = "1.13.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,9 +8,25 @@ pub enum Error {
     /// If the system theme mode could not be detected.
     DetectionFailed,
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
     /// If the XDG Desktop Portal could not be communicated with.
     XdgDesktopPortal(ashpd::Error),
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    /// If the timeout is reached.
+    Timeout,
 
     /// Failed to get persistent domain for Apple Global Domain
     #[cfg(target_os = "macos")]
@@ -35,8 +51,22 @@ impl Display for Error {
         match self {
             Error::Io(error) => write!(f, "I/O error: {}", error),
             Error::DetectionFailed => write!(f, "Failed to detect system theme mode"),
-            #[cfg(target_os = "linux")]
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ))]
             Error::XdgDesktopPortal(err) => write!(f, "XDG Desktop Portal error: {}", err),
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ))]
+            Error::Timeout => write!(f, "Timeout reached"),
             #[cfg(target_os = "macos")]
             Error::PersistentDomainFailed => {
                 write!(f, "Failed to get persistent domain for Apple Global Domain")
@@ -61,7 +91,13 @@ impl From<std::io::Error> for Error {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 impl From<ashpd::Error> for Error {
     fn from(error: ashpd::Error) -> Self {
         Error::XdgDesktopPortal(error)

--- a/src/platforms/freedesktop.rs
+++ b/src/platforms/freedesktop.rs
@@ -1,9 +1,17 @@
+use std::time::Duration;
+
 use crate::{Error, Mode};
+
 use ashpd::desktop::settings::ColorScheme as PortalColorScheme;
 use ashpd::desktop::settings::Settings as XdgPortalSettings;
+use async_std::{future, task};
 
 pub fn detect() -> Result<Mode, Error> {
-    futures_lite::future::block_on(get_color_scheme())
+    task::block_on(async {
+        future::timeout(Duration::from_millis(25), get_color_scheme())
+            .await
+            .map_err(|_| Error::Timeout)?
+    })
 }
 
 pub(crate) async fn get_color_scheme() -> Result<Mode, Error> {


### PR DESCRIPTION
This pull request removes `futures-lite` in favor of `async-std` as we are already using it with `ashpd`, fixes issues with the `Error` enum and removes unnecessary dependencies.

### Improvements:

* `src/error.rs`: Updated `Error` enum and related implementations to support FreeBSD, DragonFly, NetBSD, and OpenBSD in addition to Linux.
* `src/error.rs`: Added a new `Timeout` variant to the `Error` enum to handle timeout errors.
* `src/platforms/freedesktop.rs`: Implemented timeout handling using `async-std` in the `detect` function to improve robustness.
* `Cargo.toml`: Updated dependencies by removing `futures-lite` and `tokio`, and adding `async-std`.

Fixes #17 