### PR TITLE
chore: prepare for `objc2-foundation` v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ winreg = "0.52.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.2"
-objc2-foundation = { version = "0.2.0", features = [
+objc2-foundation = { version = "0.2.0", default-features = false, features = [
+    "std",
     "NSObject",
     "NSString",
     "NSDictionary",


### PR DESCRIPTION
The next version of `objc2-foundation` will have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR pre-emptively disables them, so that your compile times down blow up once you upgrade to the next version (which is yet to be released, but will be soon).