### PR TITLE
Bumped ashpd to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.78.0"
 [dependencies]
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-ashpd = { version = "0.10.0", default-features = false, features = [
+ashpd = { version = "0.11.0", default-features = false, features = [
     "async-std",
 ] }
 async-std = "1.13.0"


### PR DESCRIPTION
Was running into build errors cause of ashpd 0.10.0: https://github.com/squidowl/halloy/actions/runs/13594170138/job/38007165179. I've bumped to newest (0.11.0) which solved it.