### PR TITLE
feat: remove ashpd use zbus directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ readme = "README.md"
 build = "build.rs"
 rust-version = "1.78.0"
 
+[features]
+default = ["async-io"]
+tokio = ["zbus/tokio"]
+async-io = ["zbus/async-io"]
+
 [dependencies]
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,7 @@ rust-version = "1.78.0"
 [dependencies]
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-ashpd = { version = "0.11.0", default-features = false, features = [
-    "async-std",
-] }
-async-std = "1.13.0"
+zbus = "5.5.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"

--- a/src/platforms/freedesktop.rs
+++ b/src/platforms/freedesktop.rs
@@ -1,31 +1,37 @@
-use std::time::Duration;
-
 use crate::{Error, Mode};
+use zbus::proxy;
+use zbus::zvariant::OwnedValue;
 
-use ashpd::desktop::settings::ColorScheme as PortalColorScheme;
-use ashpd::desktop::settings::Settings as XdgPortalSettings;
-use async_std::{future, task};
+const APPEARANCE: &str = "org.freedesktop.appearance";
+const COLOR_SCHEME: &str = "color-scheme";
+const PROTAL_DESTINATION: &str = "org.freedesktop.portal.Desktop";
 
+#[proxy(
+    interface = "org.freedesktop.portal.Settings",
+    default_path = "/org/freedesktop/portal/desktop"
+)]
+pub trait XdgProtalSettings {
+    fn read_one(&self, namespace: &str, key: &str) -> zbus::Result<OwnedValue>;
+}
 pub fn detect() -> Result<Mode, Error> {
-    task::block_on(future::timeout(Duration::from_millis(25), async {
-        let settings = XdgPortalSettings::new()
-            .await
-            .map_err(|e| Error::XdgDesktopPortal(e.to_string()))?;
-        let color_scheme = settings
-            .color_scheme()
-            .await
-            .map_err(|e| Error::XdgDesktopPortal(e.to_string()))?;
-        Ok::<Mode, Error>(color_scheme.into())
-    }))
-    .map_err(|_| Error::Timeout)?
+    let conn = zbus::blocking::Connection::session()
+        .map_err(|e| Error::XdgDesktopPortal(e.to_string()))?;
+    let portal = XdgProtalSettingsProxyBlocking::new(&conn, PROTAL_DESTINATION)
+        .map_err(|e| Error::XdgDesktopPortal(e.to_string()))?;
+    let settings: u32 = portal
+        .read_one(APPEARANCE, COLOR_SCHEME)
+        .map_err(|e| Error::XdgDesktopPortal(e.to_string()))?
+        .try_into()
+        .map_err(|_| Error::XdgDesktopPortal("type convert failed".to_string()))?;
+    Ok(settings.into())
 }
 
-impl From<PortalColorScheme> for Mode {
-    fn from(value: PortalColorScheme) -> Self {
+impl From<u32> for Mode {
+    fn from(value: u32) -> Self {
         match value {
-            PortalColorScheme::NoPreference => Mode::Unspecified,
-            PortalColorScheme::PreferDark => Mode::Dark,
-            PortalColorScheme::PreferLight => Mode::Light,
+            1 => Mode::Dark,
+            2 => Mode::Light,
+            _ => Mode::Unspecified,
         }
     }
 }

--- a/src/platforms/freedesktop.rs
+++ b/src/platforms/freedesktop.rs
@@ -4,34 +4,29 @@ use zbus::zvariant::OwnedValue;
 
 const APPEARANCE: &str = "org.freedesktop.appearance";
 const COLOR_SCHEME: &str = "color-scheme";
-const PROTAL_DESTINATION: &str = "org.freedesktop.portal.Desktop";
+const PORTAL_DESTINATION: &str = "org.freedesktop.portal.Desktop";
 
 #[proxy(
     interface = "org.freedesktop.portal.Settings",
     default_path = "/org/freedesktop/portal/desktop"
 )]
-pub trait XdgProtalSettings {
+pub trait XdgPortalSettings {
     fn read_one(&self, namespace: &str, key: &str) -> zbus::Result<OwnedValue>;
 }
+
 pub fn detect() -> Result<Mode, Error> {
     let conn = zbus::blocking::Connection::session()
         .map_err(|e| Error::XdgDesktopPortal(e.to_string()))?;
-    let portal = XdgProtalSettingsProxyBlocking::new(&conn, PROTAL_DESTINATION)
+    let portal = XdgPortalSettingsProxyBlocking::new(&conn, PORTAL_DESTINATION)
         .map_err(|e| Error::XdgDesktopPortal(e.to_string()))?;
-    let settings: u32 = portal
+    let mode_value: u32 = portal
         .read_one(APPEARANCE, COLOR_SCHEME)
         .map_err(|e| Error::XdgDesktopPortal(e.to_string()))?
         .try_into()
         .map_err(|_| Error::XdgDesktopPortal("type convert failed".to_string()))?;
-    Ok(settings.into())
-}
-
-impl From<u32> for Mode {
-    fn from(value: u32) -> Self {
-        match value {
-            1 => Mode::Dark,
-            2 => Mode::Light,
-            _ => Mode::Unspecified,
-        }
-    }
+    Ok(match mode_value {
+        1 => Mode::Dark,
+        2 => Mode::Light,
+        _ => Mode::Unspecified,
+    })
 }


### PR DESCRIPTION
zbus use tokio and async-std together, this cause some buggy thing, for example, in this project, it try to use async-std to run a async flow in blocking flow, but if I induced another zbus, and enable the tokio feature, then it runs with tokio feature, this cause the whole thread panic. So if you want to use blocking function with zbus, I think it is better to use the blocking feature of zbus instead, not with such buggy way

influence: https://github.com/iced-rs/iced/issues/2833