### PR TITLE
Upgrade objc2 to 0.6.3 and Remove Unsafe Block #70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ zbus = "5.5.0"
 winreg = "0.52.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.5.2"
-objc2-foundation = { version = "0.2.0", default-features = false, features = [
+objc2 = "0.6.3"
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
     "std",
     "NSObject",
     "NSString",

--- a/src/platforms/macos.rs
+++ b/src/platforms/macos.rs
@@ -2,22 +2,36 @@
 // Written with help from Ryan McGrath (https://rymc.io/).
 
 use crate::{Error, Mode};
-use objc2::rc::Retained;
 use objc2_foundation::{ns_string, NSString, NSUserDefaults};
 
 pub fn detect() -> Result<Mode, Error> {
-    unsafe {
-        let style = NSUserDefaults::standardUserDefaults()
-            .persistentDomainForName(ns_string!("Apple Global Domain"))
-            .ok_or(Error::PersistentDomainFailed)?
-            .objectForKey(ns_string!("AppleInterfaceStyle"));
+    let style = NSUserDefaults::standardUserDefaults()
+        .persistentDomainForName(ns_string!("Apple Global Domain"))
+        .ok_or(Error::PersistentDomainFailed)?
+        .objectForKey(ns_string!("AppleInterfaceStyle"));
 
-        let Some(style) = style else {
-            return Ok(Mode::Light);
-        };
+    let Some(style) = style else {
+        return Ok(Mode::Light);
+    };
 
-        let style = Retained::cast::<NSString>(style);
-        let mode = style.isEqualToString(ns_string!("Dark")).into();
-        Ok(mode)
+    let Ok(style) = style.downcast::<NSString>() else {
+        return Err(Error::PersistentDomainFailed);
+    };
+    let mode = style.isEqualToString(ns_string!("Dark")).into();
+    Ok(mode)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_returns_mode() {
+        let result = detect();
+        assert!(result.is_ok(), "detect() should return a valid mode");
+        let mode = result.unwrap();
+        if !matches!(mode, Mode::Light | Mode::Dark) {
+            eprintln!("Warning: Unexpected mode value: {:?}", mode);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Upgraded `objc2` from v0.5.2 to v0.6.3
- Upgraded `objc2-foundation` from v0.2.2 to v0.3.2
- Added conservative unit test and validated working locally
- Replaced deprecated `Retained::cast()` with safe `downcast()` method
- Eliminated unsafe block from macOS detection code

## Benefits
- Improved safety: No unsafe blocks in macOS platform code
- Better error handling: `downcast()` provides proper error handling for type conversion failures
- Future-proofing: Uses current / non-deprecated APIs from objc2 0.6.x

